### PR TITLE
Fixed issue related with arrows and note trails

### DIFF
--- a/assets/images/NOTE_assets.xml
+++ b/assets/images/NOTE_assets.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <TextureAtlas imagePath="NOTE_assets.png">
 	<!-- Created with Adobe Animate version 20.0.0.17400 -->
 	<!-- http://www.adobe.com/products/animate.html -->
@@ -11,8 +11,8 @@
 	<SubTexture name="blue hold piece0000" x="1370" y="449" width="50" height="44"/>
 	<SubTexture name="down confirm0000" x="0" y="0" width="238" height="235"/>
 	<SubTexture name="down confirm0001" x="238" y="0" width="238" height="235"/>
-	<SubTexture name="down confirm0002" x="1176" y="230" width="220" height="217" frameX="-6" frameY="-12" frameWidth="238" frameHeight="235"/>
-	<SubTexture name="down confirm0003" x="1176" y="230" width="220" height="217" frameX="-6" frameY="-12" frameWidth="238" frameHeight="235"/>
+	<SubTexture name="down confirm0002" x="1176" y="230" width="219" height="208" frameX="-6" frameY="-12" frameWidth="238" frameHeight="235"/>
+	<SubTexture name="down confirm0003" x="1176" y="230" width="219" height="208" frameX="-6" frameY="-12" frameWidth="238" frameHeight="235"/>
 	<SubTexture name="down press0000" x="149" y="392" width="142" height="140" frameX="-4" frameY="-2" frameWidth="149" frameHeight="146"/>
 	<SubTexture name="down press0001" x="149" y="392" width="142" height="140" frameX="-4" frameY="-2" frameWidth="149" frameHeight="146"/>
 	<SubTexture name="down press0002" x="0" y="388" width="149" height="146"/>
@@ -22,8 +22,8 @@
 	<SubTexture name="green hold piece0000" x="1320" y="447" width="50" height="44"/>
 	<SubTexture name="left confirm0000" x="948" y="0" width="228" height="231"/>
 	<SubTexture name="left confirm0001" x="1402" y="228" width="218" height="221" frameX="-5" frameY="-5" frameWidth="228" frameHeight="231"/>
-	<SubTexture name="left confirm0002" x="1402" y="0" width="225" height="228" frameX="-2" frameY="-1" frameWidth="228" frameHeight="231"/>
-	<SubTexture name="left confirm0003" x="1402" y="0" width="225" height="228" frameX="-2" frameY="-1" frameWidth="228" frameHeight="231"/>
+	<SubTexture name="left confirm0002" x="1402" y="0" width="225" height="221" frameX="-2" frameY="-1" frameWidth="228" frameHeight="231"/>
+	<SubTexture name="left confirm0003" x="1402" y="0" width="225" height="221" frameX="-2" frameY="-1" frameWidth="228" frameHeight="231"/>
 	<SubTexture name="left press0000" x="291" y="392" width="140" height="142" frameX="-3" frameY="-3" frameWidth="146" frameHeight="149"/>
 	<SubTexture name="left press0001" x="291" y="392" width="140" height="142" frameX="-3" frameY="-3" frameWidth="146" frameHeight="149"/>
 	<SubTexture name="left press0002" x="463" y="389" width="146" height="149"/>
@@ -44,8 +44,8 @@
 	<SubTexture name="right press0003" x="784" y="385" width="148" height="151"/>
 	<SubTexture name="up confirm0000" x="476" y="0" width="236" height="232"/>
 	<SubTexture name="up confirm0001" x="712" y="0" width="236" height="232"/>
-	<SubTexture name="up confirm0002" x="948" y="231" width="214" height="211" frameX="-11" frameY="-10" frameWidth="236" frameHeight="232"/>
-	<SubTexture name="up confirm0003" x="948" y="231" width="214" height="211" frameX="-11" frameY="-10" frameWidth="236" frameHeight="232"/>
+	<SubTexture name="up confirm0002" x="948" y="231" width="214" height="206" frameX="-11" frameY="-10" frameWidth="236" frameHeight="232"/>
+	<SubTexture name="up confirm0003" x="948" y="231" width="214" height="206" frameX="-11" frameY="-10" frameWidth="236" frameHeight="232"/>
 	<SubTexture name="up press0000" x="609" y="389" width="144" height="141" frameX="-5" frameY="-4" frameWidth="153" frameHeight="150"/>
 	<SubTexture name="up press0001" x="609" y="389" width="144" height="141" frameX="-5" frameY="-4" frameWidth="153" frameHeight="150"/>
 	<SubTexture name="up press0002" x="1850" y="308" width="153" height="150"/>


### PR DESCRIPTION
There was an issue related with how the notes were set in the flash xml file. Basically, there's this bug that appears when you hold a note with any of the arrows for a period of time and the camera moves:

![trailsbug](https://user-images.githubusercontent.com/69006987/101070246-6247ae80-359b-11eb-827b-c8c2212b7c6e.png)
 
These are the trails of the notes that are down the confirm arrows and that in the xml they are set too close of each other, so I tweaked it a little bit by changing some pixels without modifying the origin of the animation too much.

![image](https://user-images.githubusercontent.com/69006987/101069708-a6867f00-359a-11eb-831e-2c1b674b69f6.png)
