### PR TITLE
Fix crash when playing other levels after playing Week 3

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -94,6 +94,8 @@ class PlayState extends MusicBeatState
 
 	override public function create()
 	{
+		//Reset curStage or level specific events (like the window lights in philly) will cause a crash when loading other levels
+		curStage = '';
 		// var gameCam:FlxCamera = FlxG.camera;
 		camGame = new FlxCamera();
 		camHUD = new FlxCamera();


### PR DESCRIPTION
Should fix https://github.com/ninjamuffin99/Funkin/issues/75, https://github.com/ninjamuffin99/Funkin/issues/91, https://github.com/ninjamuffin99/Funkin/issues/83 and possibly https://github.com/ninjamuffin99/Funkin/issues/69

Hopefully I didn't mess this PR up

Fixes the crash that happens if you play a level after playing Week 3, where the game tries to run code on the philly lights but fails because they no longer exist.