### PR TITLE
Added a fix to music restarting when the song ends.

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1028,7 +1028,7 @@ class PlayState extends MusicBeatState
 	function endSong():Void
 	{
 		canPause = false;
-
+		FlxG.sound.music = new FlxSound();
 		if (SONG.validScore)
 		{
 			#if !switch


### PR DESCRIPTION
Fixed a bug that would cause the song to repeat after it ended during the transition. Honestly I can't explain this very well so hopefully this video does a better job.

Note: this bug would sometimes not occur if the game was paused at some point.

https://user-images.githubusercontent.com/24728334/103337172-4a930700-4a2f-11eb-9c68-22427a35b4df.mp4

