### PR TITLE
Move version check screen to TitleState

### DIFF
--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -89,13 +89,6 @@ class MainMenuState extends MusicBeatState
 		versionShit.setFormat("VCR OSD Mono", 16, FlxColor.WHITE, LEFT, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
 		add(versionShit);
 
-		if (versionShit.text.trim() != NGio.GAME_VER.trim() && !OutdatedSubState.leftState)
-		{
-			trace('OLD VERSION!');
-
-			FlxG.switchState(new OutdatedSubState());
-		}
-
 		// NG.core.calls.event.logEvent('swag').send();
 
 		changeItem();

--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -20,8 +20,12 @@ import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
 import flixel.util.FlxColor;
 import flixel.util.FlxTimer;
+import io.newgrounds.NG;
+import lime.app.Application;
 import lime.utils.Assets;
 import polymod.Polymod;
+
+using StringTools;
 
 class TitleState extends MusicBeatState
 {
@@ -261,7 +265,19 @@ class TitleState extends MusicBeatState
 
 			new FlxTimer().start(2, function(tmr:FlxTimer)
 			{
-				FlxG.switchState(new MainMenuState());
+				// Check if version is outdated
+
+				var version:String = "v" + Application.current.meta.get('version');
+
+				if (version.trim() != NGio.GAME_VER.trim() && !OutdatedSubState.leftState)
+				{
+					trace('OLD VERSION!');
+					FlxG.switchState(new OutdatedSubState());
+				}
+				else
+				{
+					FlxG.switchState(new MainMenuState());
+				}
 			});
 			// FlxG.sound.play('assets/music/titleShoot' + TitleState.soundExt, 0.7);
 		}


### PR DESCRIPTION
Moving the version check screen to TitleState, allows the game to make early decisions whether to switch to MainMenuState or OutdatedSubState.
Also solves the weird trantition bug.

**Before:**

https://user-images.githubusercontent.com/10368254/103624260-40fc2880-4f74-11eb-856e-d4dd53ca79fe.mp4

**After:**

https://user-images.githubusercontent.com/10368254/103624355-5ec98d80-4f74-11eb-9aee-f44fe5c28cbd.mp4

Let me know if there needs to be a change before merging. Thanks.