### PR TITLE
Don't show FPS counter when built with -final

### DIFF
--- a/art/build-Itch-WINDOWS.bat
+++ b/art/build-Itch-WINDOWS.bat
@@ -3,10 +3,10 @@ color 0a
 cd ..
 @echo on
 echo BUILDING GAME
-lime build windows -release
+lime build windows -final
 echo UPLOADING 64 BIT VERSION TO ITCH
 butler push ./export/release/windows/bin ninja-muffin24/funkin:windows-64bit
-lime build windows -release -32
+lime build windows -final -32
 echo UPLOADING 32 BIT VERSION TO ITCH
 butler push ./export/release/windows/bin ninja-muffin24/funkin:windows-32bit
 butler status ninja-muffin24/funkin:windows-32bit

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -1,7 +1,9 @@
 package;
 
 import flixel.FlxGame;
+#if !final
 import openfl.display.FPS;
+#end
 import openfl.display.Sprite;
 
 class Main extends Sprite
@@ -11,7 +13,7 @@ class Main extends Sprite
 		super();
 		addChild(new FlxGame(0, 0, TitleState));
 
-		#if !mobile
+		#if !final
 		addChild(new FPS(10, 3, 0xFFFFFF));
 		#end
 	}


### PR DESCRIPTION
Removes the FPS counter at the top left when the game is built with `-final`. This PR also modifies one of the build scripts to build with `-final` instead of `-release`.

This means when someone were to ever build for mobile (it's a pain to set up and crashes after haxeflixel logo lol), it would show the FPS counter as well, unless it were built with `-final`.