### PR TITLE
Fixed issue with bf-christmas and bf-car resetting animations too early

### DIFF
--- a/source/Character.hx
+++ b/source/Character.hx
@@ -393,7 +393,7 @@ class Character extends FlxSprite
 
 	override function update(elapsed:Float)
 	{
-		if (curCharacter != 'bf')
+		if (curCharacter != 'bf' && curCharacter != 'bf-christmas' && curCharacter != 'bf-car')
 		{
 			if (animation.curAnim.name.startsWith('sing'))
 			{


### PR DESCRIPTION
There was an issue where Both bf-christmas and bf-car were resetting their animations too early and were briefly in their idle animations.

Before:

https://user-images.githubusercontent.com/24728334/105255118-d8967500-5b37-11eb-9c07-d08505f312dc.mp4

After:

https://user-images.githubusercontent.com/24728334/105255161-ea781800-5b37-11eb-84b5-d63f73217834.mp4

Edit: sorry if the videos don't load correctly.