### PR TITLE
Add outline to score text

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -482,6 +482,7 @@ class PlayState extends MusicBeatState
 
 		scoreTxt = new FlxText(healthBarBG.x + healthBarBG.width - 190, healthBarBG.y + 30, 0, "", 20);
 		scoreTxt.setFormat("assets/fonts/vcr.ttf", 16, FlxColor.WHITE, RIGHT);
+		scoreTxt.setBorderStyle(OUTLINE, 0xFF000000, 2, 1);
 		scoreTxt.scrollFactor.set();
 		add(scoreTxt);
 


### PR DESCRIPTION
Allows the score text to be readable in winter stages like Cocoa and Eggnog.

<img width="640" alt="2021-01-24_20-19-56_Funkin" src="https://user-images.githubusercontent.com/15317421/105661209-becf9780-5e81-11eb-8ac1-84430646deb2.png">
<img width="640" alt="2021-01-24_20-20-10_Funkin" src="https://user-images.githubusercontent.com/15317421/105661212-c000c480-5e81-11eb-9d0d-84bb8c26e055.png">

I tried making it easy to read while not looking too bad, but the values can be adjusted if necessary.

(I also tried making the score black for these specific stages instead of using a global outline but I felt like the difference between stages would be jarring)