### PR TITLE
Update bug.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -29,4 +29,4 @@ labels: bug
 
 ## Have you identified any steps to reproduce the bug? If so, please describe them below. Use images if possible.
 
-## Please describe your issue. Provide extensive detail and images if possibe.
+## Please describe your issue. Provide extensive detail and images if possible.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -9,7 +9,7 @@ labels: bug
 
 ## Where are you playing the game?
 
-### Web
+### Web (Only check if playing online)
 - [ ] [Newgrounds](https://www.newgrounds.com/portal/view/770371)
 - [ ] [Itch.io](https://ninja-muffin24.itch.io/funkin)
 
@@ -19,7 +19,7 @@ labels: bug
 - [ ] Safari
 - [ ] Other, please specify:
 
-### Local
+### Local (Only check if you've downloaded the game.)
 - [ ] Windows x86
 - [ ] Windows x86_64
 - [ ] Linux


### PR DESCRIPTION
add a note to the Local category to tell users to only select one if game is downloaded, and only select for Web if playing on NG or itch.io

I notice a lot of users check a platform in the Local category when playing on web, and vice versa.