### PR TITLE
Issue Management Workflows

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,0 +1,24 @@
+name: First Interaction
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: 'Hi! It looks like this is your first time contributing to [Friday Night Funkin](https://github.com/ninjamuffin99/funkin), or maybe even your first time using GitHub!\nPlease make sure that this issue is properly organized and uses the proper template. Invalid issues may be removed or ignored.'
+          pr-message: Hi! It looks like this is your first time contributing to [Friday Night Funkin](https://github.com/ninjamuffin99/funkin), or maybe even your first time using GitHub!\nPlease make sure that this PR is properly organized and uses the proper template. Invalid PRs may be removed or ignored.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: 'Stale issue handler'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@main
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 20 days with no activity. Remove stale label or comment or this will be closed in 3 days'
+          days-before-stale: 20
+          days-before-close: 3


### PR DESCRIPTION
There are a lot of issues pouring in, mostly from first time open-source contributors.

These workflows should help clean up all the invalid and spam issues.

Note: This is more of a suggestion than anything else. There are a lot of invalid/spam issues and it may be hard to cut through the noise and find legitmate issues that nee fixing. Semi-dependant on #342 and #300.