### PR TITLE
check if newgroups api key actually exists before creating core

### DIFF
--- a/source/NGio.hx
+++ b/source/NGio.hx
@@ -35,19 +35,22 @@ class NGio
 		trace('INIT NOLOGIN');
 		GAME_VER = "v" + Application.current.meta.get('version');
 
-		NG.create(api);
-
-		new FlxTimer().start(2, function(tmr:FlxTimer)
+		if (api.length != 0)
 		{
-			var call = NG.core.calls.app.getCurrentVersion(GAME_VER).addDataHandler(function(response:Response<GetCurrentVersionResult>)
-			{
-				GAME_VER = response.result.data.current_version;
-				trace('CURRENT NG VERSION: ' + GAME_VER);
-				gotOnlineVer = true;
-			});
+			NG.create(api);
 
-			call.send();
-		});
+			new FlxTimer().start(2, function(tmr:FlxTimer)
+			{
+				var call = NG.core.calls.app.getCurrentVersion(GAME_VER).addDataHandler(function(response:Response<GetCurrentVersionResult>)
+				{
+					GAME_VER = response.result.data.current_version;
+					trace('CURRENT NG VERSION: ' + GAME_VER);
+					gotOnlineVer = true;
+				});
+
+				call.send();
+			});
+		}
 	}
 
 	public function new(api:String, encKey:String, ?sessionId:String)


### PR DESCRIPTION
Following the README and using this as the contents for `APIStuff.hx`
```
class APIStuff
{
	public static var API:String = "";
	public static var EncKey:String = "";
}
```
results in the game quitting due to the invalid API key
lets check if the api key is not empty before creating the core so we don't run into this
