### PR TITLE
BPM change functionality & implementation

### DIFF
--- a/source/ChartingState.hx
+++ b/source/ChartingState.hx
@@ -2,6 +2,7 @@ package;
 
 import Section.SwagSection;
 import Song.SwagSong;
+import Conductor.BPMChangeEvent;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.addons.display.FlxGridOverlay;
@@ -117,11 +118,9 @@ class ChartingState extends MusicBeatState
 				song: 'Test',
 				notes: [],
 				bpm: 150,
-				sections: 0,
 				needsVoices: true,
 				player1: 'bf',
 				player2: 'dad',
-				sectionLengths: [],
 				speed: 1,
 				validScore: false
 			};
@@ -140,6 +139,7 @@ class ChartingState extends MusicBeatState
 
 		loadSong(_song.song);
 		Conductor.changeBPM(_song.bpm);
+		Conductor.mapBPMChanges(_song);
 
 		bpmTxt = new FlxText(1000, 50, 0, "", 16);
 		bpmTxt.scrollFactor.set();
@@ -366,6 +366,7 @@ class ChartingState extends MusicBeatState
 			vocals.time = 0;
 			FlxG.sound.music.pause();
 			FlxG.sound.music.time = 0;
+			changeSection();
 		};
 	}
 
@@ -425,6 +426,7 @@ class ChartingState extends MusicBeatState
 			else if (wname == 'song_bpm')
 			{
 				tempBpm = Std.int(nums.value);
+				Conductor.mapBPMChanges(_song);
 				Conductor.changeBPM(Std.int(nums.value));
 			}
 			else if (wname == 'note_susLength')
@@ -444,12 +446,27 @@ class ChartingState extends MusicBeatState
 
 	var updatedSection:Bool = false;
 
+	/* this function got owned LOL
 	function lengthBpmBullshit():Float
 	{
 		if (_song.notes[curSection].changeBPM)
 			return _song.notes[curSection].lengthInSteps * (_song.notes[curSection].bpm / _song.bpm);
 		else
 			return _song.notes[curSection].lengthInSteps;
+	}*/
+
+	function sectionStartTime():Float
+	{
+		var daBPM:Int = _song.bpm;
+		var daPos:Float = 0;
+		for (i in 0...curSection)
+		{
+			if (_song.notes[i].changeBPM) {
+				daBPM = _song.notes[i].bpm;
+			}
+			daPos += 4 * (1000 * 60 / daBPM);
+		}
+		return daPos;
 	}
 
 	override function update(elapsed:Float)
@@ -459,23 +476,20 @@ class ChartingState extends MusicBeatState
 		Conductor.songPosition = FlxG.sound.music.time;
 		_song.song = typingShit.text;
 
-		strumLine.y = getYfromStrum(Conductor.songPosition % (Conductor.stepCrochet * lengthBpmBullshit()));
+		strumLine.y = getYfromStrum((Conductor.songPosition - sectionStartTime()) % (Conductor.stepCrochet * _song.notes[curSection].lengthInSteps));
 
-		if (curBeat % 4 == 0)
+		if (curBeat % 4 == 0 && curStep >= 16 * (curSection + 1))
 		{
-			if (curStep > 16 * (curSection + 1))
+			trace(curStep);
+			trace((_song.notes[curSection].lengthInSteps) * (curSection + 1));
+			trace('DUMBSHIT');
+
+			if (_song.notes[curSection + 1] == null)
 			{
-				trace(curStep);
-				trace((_song.notes[curSection].lengthInSteps) * (curSection + 1));
-				trace('DUMBSHIT');
-
-				if (_song.notes[curSection + 1] == null)
-				{
-					addSection();
-				}
-
-				changeSection(curSection + 1, false);
+				addSection();
 			}
+
+			changeSection(curSection + 1, false);
 		}
 
 		FlxG.watch.addQuick('daBeat', curBeat);
@@ -674,21 +688,18 @@ class ChartingState extends MusicBeatState
 
 	function recalculateSteps():Int
 	{
-		var steps:Int = 0;
-		var timeShit:Float = 0;
-
-		for (i in 0...curSection)
+		var lastChange:BPMChangeEvent = {
+			stepTime: 0,
+			songTime: 0,
+			bpm: 0
+		}
+		for (i in 0...Conductor.bpmChangeMap.length)
 		{
-			steps += 16;
-
-			if (_song.notes[i].changeBPM)
-				timeShit += (((60 / _song.notes[i].bpm) * 1000) / 4) * 16;
-			else
-				timeShit += (((60 / _song.bpm) * 1000) / 4) * 16;
+			if (FlxG.sound.music.time > Conductor.bpmChangeMap[i].songTime)
+				lastChange = Conductor.bpmChangeMap[i];
 		}
 
-		steps += Math.floor((FlxG.sound.music.time - timeShit) / Conductor.stepCrochet);
-		curStep = steps;
+		curStep = lastChange.stepTime + Math.floor((FlxG.sound.music.time - lastChange.songTime) / Conductor.stepCrochet);
 		updateBeat();
 
 		return curStep;
@@ -702,7 +713,7 @@ class ChartingState extends MusicBeatState
 		vocals.pause();
 
 		// Basically old shit from changeSection???
-		FlxG.sound.music.time = lengthBpmBullshit() * Conductor.stepCrochet * curSection;
+		FlxG.sound.music.time = sectionStartTime();
 
 		if (songBeginning)
 		{
@@ -732,15 +743,15 @@ class ChartingState extends MusicBeatState
 				FlxG.sound.music.pause();
 				vocals.pause();
 
-				var daNum:Int = 0;
+				/*var daNum:Int = 0;
 				var daLength:Float = 0;
 				while (daNum <= sec)
 				{
 					daLength += lengthBpmBullshit();
 					daNum++;
-				}
+				}*/
 
-				FlxG.sound.music.time = (daLength - lengthBpmBullshit()) * Conductor.stepCrochet;
+				FlxG.sound.music.time = sectionStartTime();
 				vocals.time = FlxG.sound.music.time;
 				updateCurStep();
 			}
@@ -815,10 +826,16 @@ class ChartingState extends MusicBeatState
 		if (_song.notes[curSection].changeBPM && _song.notes[curSection].bpm > 0)
 		{
 			Conductor.changeBPM(_song.notes[curSection].bpm);
+			FlxG.log.add('CHANGED BPM!');
 		}
 		else
 		{
-			Conductor.changeBPM(tempBpm);
+			//get last bpm
+			var daBPM:Int = _song.bpm;
+			for (i in 0...curSection)
+				if (_song.notes[i].changeBPM)
+					daBPM = _song.notes[i].bpm;
+			Conductor.changeBPM(daBPM);
 		}
 
 		/* // PORT BULLSHIT, INCASE THERE'S NO SUSTAIN DATA FOR A NOTE
@@ -846,7 +863,7 @@ class ChartingState extends MusicBeatState
 			note.setGraphicSize(GRID_SIZE, GRID_SIZE);
 			note.updateHitbox();
 			note.x = Math.floor(daNoteInfo * GRID_SIZE);
-			note.y = Math.floor(getYfromStrum(daStrumTime)) % gridBG.height;
+			note.y = Math.floor(getYfromStrum((daStrumTime - sectionStartTime()) % (Conductor.stepCrochet * _song.notes[curSection].lengthInSteps)));
 
 			curRenderedNotes.add(note);
 
@@ -925,7 +942,7 @@ class ChartingState extends MusicBeatState
 
 	private function addNote():Void
 	{
-		var noteStrum = getStrumTime(dummyArrow.y) + (curSection * (Conductor.stepCrochet * 16));
+		var noteStrum = getStrumTime(dummyArrow.y) + sectionStartTime();
 		var noteData = Math.floor(FlxG.mouse.x / GRID_SIZE);
 		var noteSus = 0;
 
@@ -938,7 +955,7 @@ class ChartingState extends MusicBeatState
 			_song.notes[curSection].sectionNotes.push([noteStrum, (noteData + 4) % 8, noteSus]);
 		}
 
-		trace(getStrumTime(dummyArrow.y) + (curSection * (Conductor.stepCrochet * lengthBpmBullshit())));
+		trace(noteStrum);
 		trace(curSection);
 
 		updateGrid();
@@ -957,6 +974,7 @@ class ChartingState extends MusicBeatState
 		return FlxMath.remapToRange(strumTime, 0, 16 * Conductor.stepCrochet, gridBG.y, gridBG.y + gridBG.height);
 	}
 
+	/*
 	function calculateSectionLengths(?sec:SwagSection):Int
 	{
 		var daLength:Int = 0;
@@ -978,7 +996,7 @@ class ChartingState extends MusicBeatState
 		}
 
 		return daLength;
-	}
+	}*/
 
 	private var daSpacing:Float = 0.3;
 
@@ -1014,10 +1032,7 @@ class ChartingState extends MusicBeatState
 	function autosaveSong():Void
 	{
 		FlxG.save.data.autosave = Json.stringify({
-			"song": _song,
-			"bpm": Conductor.bpm,
-			"sections": _song.notes.length,
-			'notes': _song.notes
+			"song": _song
 		});
 		FlxG.save.flush();
 	}
@@ -1025,10 +1040,7 @@ class ChartingState extends MusicBeatState
 	private function saveLevel()
 	{
 		var json = {
-			"song": _song,
-			"bpm": Conductor.bpm,
-			"sections": _song.notes.length,
-			'notes': _song.notes
+			"song": _song
 		};
 
 		var data:String = Json.stringify(json);

--- a/source/Conductor.hx
+++ b/source/Conductor.hx
@@ -1,9 +1,19 @@
 package;
 
+import Song.SwagSong;
+
 /**
  * ...
  * @author
  */
+
+typedef BPMChangeEvent =
+{
+	var stepTime:Int;
+	var songTime:Float;
+	var bpm:Int;
+}
+
 class Conductor
 {
 	public static var bpm:Int = 100;
@@ -16,8 +26,37 @@ class Conductor
 	public static var safeFrames:Int = 10;
 	public static var safeZoneOffset:Float = (safeFrames / 60) * 1000; // is calculated in create(), is safeFrames in milliseconds
 
+	public static var bpmChangeMap:Array<BPMChangeEvent> = [];
+
 	public function new()
 	{
+	}
+
+	public static function mapBPMChanges(song:SwagSong)
+	{
+		bpmChangeMap = [];
+
+		var curBPM:Int = song.bpm;
+		var totalSteps:Int = 0;
+		var totalPos:Float = 0;
+		for (i in 0...song.notes.length)
+		{
+			if(song.notes[i].changeBPM && song.notes[i].bpm != curBPM)
+			{
+				curBPM = song.notes[i].bpm;
+				var event:BPMChangeEvent = {
+					stepTime: totalSteps,
+					songTime: totalPos,
+					bpm: curBPM
+				};
+				bpmChangeMap.push(event);
+			}
+
+			var deltaSteps:Int = song.notes[i].lengthInSteps;
+			totalSteps += deltaSteps;
+			totalPos += ((60 / curBPM) * 1000 / 4) * deltaSteps;
+		}
+		trace("new BPM map BUDDY " + bpmChangeMap);
 	}
 
 	public static function changeBPM(newBpm:Int)

--- a/source/MusicBeatState.hx
+++ b/source/MusicBeatState.hx
@@ -1,5 +1,6 @@
 package;
 
+import Conductor.BPMChangeEvent;
 import flixel.FlxG;
 import flixel.addons.transition.FlxTransitionableState;
 import flixel.addons.ui.FlxUIState;
@@ -38,7 +39,7 @@ class MusicBeatState extends FlxUIState
 		everyStep();
 
 		updateCurStep();
-		// Needs to be ROUNED, rather than ceil or floor
+		// Needs to be FLOOR idk why it was rounded but that dont make sense
 		updateBeat();
 
 		super.update(elapsed);
@@ -46,7 +47,7 @@ class MusicBeatState extends FlxUIState
 
 	private function updateBeat():Void
 	{
-		curBeat = Math.round(curStep / 4);
+		curBeat = Math.floor(curStep / 4);
 	}
 
 	/**
@@ -66,7 +67,18 @@ class MusicBeatState extends FlxUIState
 
 	private function updateCurStep():Void
 	{
-		curStep = Math.floor(Conductor.songPosition / Conductor.stepCrochet);
+		var lastChange:BPMChangeEvent = {
+			stepTime: 0,
+			songTime: 0,
+			bpm: 0
+		}
+		for (i in 0...Conductor.bpmChangeMap.length)
+		{
+			if (Conductor.songPosition >= Conductor.bpmChangeMap[i].songTime)
+				lastChange = Conductor.bpmChangeMap[i];
+		}
+
+		curStep = lastChange.stepTime + Math.floor((Conductor.songPosition - lastChange.songTime) / Conductor.stepCrochet);
 	}
 
 	public function stepHit():Void

--- a/source/MusicBeatState.hx
+++ b/source/MusicBeatState.hx
@@ -36,10 +36,14 @@ class MusicBeatState extends FlxUIState
 
 	override function update(elapsed:Float)
 	{
-		everyStep();
+		//everyStep();
+		var oldStep:Int = curStep;
 
 		updateCurStep();
-		// Needs to be FLOOR idk why it was rounded but that dont make sense
+
+		if (oldStep != curStep && curStep > 0)
+			stepHit();
+
 		updateBeat();
 
 		super.update(elapsed);
@@ -48,21 +52,6 @@ class MusicBeatState extends FlxUIState
 	private function updateBeat():Void
 	{
 		curBeat = Math.floor(curStep / 4);
-	}
-
-	/**
-	 * CHECKS EVERY FRAME
-	 */
-	private function everyStep():Void
-	{
-		if (Conductor.songPosition > lastStep + Conductor.stepCrochet - Conductor.safeZoneOffset
-			|| Conductor.songPosition < lastStep + Conductor.safeZoneOffset)
-		{
-			if (Conductor.songPosition > lastStep + Conductor.stepCrochet)
-			{
-				stepHit();
-			}
-		}
 	}
 
 	private function updateCurStep():Void

--- a/source/MusicBeatState.hx
+++ b/source/MusicBeatState.hx
@@ -12,9 +12,6 @@ class MusicBeatState extends FlxUIState
 	private var lastBeat:Float = 0;
 	private var lastStep:Float = 0;
 
-	private var totalBeats:Int = 0;
-	private var totalSteps:Int = 0;
-
 	private var curStep:Int = 0;
 	private var curBeat:Int = 0;
 	private var controls(get, never):Controls;
@@ -40,11 +37,10 @@ class MusicBeatState extends FlxUIState
 		var oldStep:Int = curStep;
 
 		updateCurStep();
+		updateBeat();
 
 		if (oldStep != curStep && curStep > 0)
 			stepHit();
-
-		updateBeat();
 
 		super.update(elapsed);
 	}
@@ -72,23 +68,12 @@ class MusicBeatState extends FlxUIState
 
 	public function stepHit():Void
 	{
-		totalSteps += 1;
-		lastStep += Conductor.stepCrochet;
-
-		// If the song is at least 3 steps behind
-		if (Conductor.songPosition > lastStep + (Conductor.stepCrochet * 3))
-		{
-			lastStep = Conductor.songPosition;
-			totalSteps = Math.ceil(lastStep / Conductor.stepCrochet);
-		}
-
-		if (totalSteps % 4 == 0)
+		if (curStep % 4 == 0)
 			beatHit();
 	}
 
 	public function beatHit():Void
 	{
-		lastBeat += Conductor.crochet;
-		totalBeats += 1;
+		//do literally nothing dumbass
 	}
 }

--- a/source/MusicBeatSubstate.hx
+++ b/source/MusicBeatSubstate.hx
@@ -1,5 +1,6 @@
 package;
 
+import Conductor.BPMChangeEvent;
 import flixel.FlxG;
 import flixel.FlxSubState;
 
@@ -37,7 +38,7 @@ class MusicBeatSubstate extends FlxSubState
 		everyStep();
 
 		updateCurStep();
-		curBeat = Math.round(curStep / 4);
+		curBeat = Math.floor(curStep / 4);
 
 		super.update(elapsed);
 	}
@@ -59,7 +60,18 @@ class MusicBeatSubstate extends FlxSubState
 
 	private function updateCurStep():Void
 	{
-		curStep = Math.floor(Conductor.songPosition / Conductor.stepCrochet);
+		var lastChange:BPMChangeEvent = {
+			stepTime: 0,
+			songTime: 0,
+			bpm: 0
+		}
+		for (i in 0...Conductor.bpmChangeMap.length)
+		{
+			if (Conductor.songPosition > Conductor.bpmChangeMap[i].songTime)
+				lastChange = Conductor.bpmChangeMap[i];
+		}
+
+		curStep = lastChange.stepTime + Math.floor((Conductor.songPosition - lastChange.songTime) / Conductor.stepCrochet);
 	}
 
 	public function stepHit():Void

--- a/source/MusicBeatSubstate.hx
+++ b/source/MusicBeatSubstate.hx
@@ -35,27 +35,17 @@ class MusicBeatSubstate extends FlxSubState
 
 	override function update(elapsed:Float)
 	{
-		everyStep();
+		//everyStep();
+		var oldStep:Int = curStep;
 
 		updateCurStep();
+
+		if (oldStep != curStep && curStep > 0)
+			stepHit();
+
 		curBeat = Math.floor(curStep / 4);
 
 		super.update(elapsed);
-	}
-
-	/**
-	 * CHECKS EVERY FRAME
-	 */
-	private function everyStep():Void
-	{
-		if (Conductor.songPosition > lastStep + Conductor.stepCrochet - Conductor.safeZoneOffset
-			|| Conductor.songPosition < lastStep + Conductor.safeZoneOffset)
-		{
-			if (Conductor.songPosition > lastStep + Conductor.stepCrochet)
-			{
-				stepHit();
-			}
-		}
 	}
 
 	private function updateCurStep():Void

--- a/source/MusicBeatSubstate.hx
+++ b/source/MusicBeatSubstate.hx
@@ -14,9 +14,6 @@ class MusicBeatSubstate extends FlxSubState
 	private var lastBeat:Float = 0;
 	private var lastStep:Float = 0;
 
-	private var totalBeats:Int = 0;
-	private var totalSteps:Int = 0;
-
 	private var curStep:Int = 0;
 	private var curBeat:Int = 0;
 	private var controls(get, never):Controls;
@@ -39,11 +36,11 @@ class MusicBeatSubstate extends FlxSubState
 		var oldStep:Int = curStep;
 
 		updateCurStep();
+		curBeat = Math.floor(curStep / 4);
 
 		if (oldStep != curStep && curStep > 0)
 			stepHit();
 
-		curBeat = Math.floor(curStep / 4);
 
 		super.update(elapsed);
 	}
@@ -66,16 +63,12 @@ class MusicBeatSubstate extends FlxSubState
 
 	public function stepHit():Void
 	{
-		totalSteps += 1;
-		lastStep += Conductor.stepCrochet;
-
-		if (totalSteps % 4 == 0)
+		if (curStep % 4 == 0)
 			beatHit();
 	}
 
 	public function beatHit():Void
 	{
-		lastBeat += Conductor.crochet;
-		totalBeats += 1;
+		//do literally nothing dumbass
 	}
 }

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1446,13 +1446,13 @@ class PlayState extends MusicBeatState
 			camHUD.zoom = FlxMath.lerp(1, camHUD.zoom, 0.95);
 		}
 
-		FlxG.watch.addQuick("beatShit", totalBeats);
-		FlxG.watch.addQuick("stepShit", totalSteps);
+		FlxG.watch.addQuick("beatShit", curBeat);
+		FlxG.watch.addQuick("stepShit", curStep);
 
 
 		if (curSong == 'Fresh')
 		{
-			switch (totalBeats)
+			switch (curBeat)
 			{
 				case 16:
 					camZooming = true;
@@ -1471,7 +1471,7 @@ class PlayState extends MusicBeatState
 
 		if (curSong == 'Bopeebo')
 		{
-			switch (totalBeats)
+			switch (curBeat)
 			{
 				case 128, 129, 130:
 					vocals.volume = 0;
@@ -2240,6 +2240,7 @@ class PlayState extends MusicBeatState
 
 	override function stepHit()
 	{
+		super.stepHit();
 		if (SONG.needsVoices)
 		{
 			if (vocals.time > Conductor.songPosition + 20 || vocals.time < Conductor.songPosition - 20)
@@ -2248,12 +2249,10 @@ class PlayState extends MusicBeatState
 			}
 		}
 
-		if (dad.curCharacter == 'spooky' && totalSteps % 4 == 2)
+		if (dad.curCharacter == 'spooky' && curStep % 4 == 2)
 		{
 			// dad.dance();
 		}
-
-		super.stepHit();
 	}
 
 	var lightningStrikeBeat:Int = 0;
@@ -2292,7 +2291,7 @@ class PlayState extends MusicBeatState
 			camHUD.zoom += 0.03;
 		}
 
-		if (camZooming && FlxG.camera.zoom < 1.35 && totalBeats % 4 == 0)
+		if (camZooming && FlxG.camera.zoom < 1.35 && curBeat % 4 == 0)
 		{
 			FlxG.camera.zoom += 0.015;
 			camHUD.zoom += 0.03;
@@ -2304,7 +2303,7 @@ class PlayState extends MusicBeatState
 		iconP1.updateHitbox();
 		iconP2.updateHitbox();
 
-		if (totalBeats % gfSpeed == 0)
+		if (curBeat % gfSpeed == 0)
 		{
 			gf.dance();
 		}
@@ -2314,7 +2313,7 @@ class PlayState extends MusicBeatState
 			boyfriend.playAnim('idle');
 		}
 
-		if (totalBeats % 8 == 7 && curSong == 'Bopeebo')
+		if (curBeat % 8 == 7 && curSong == 'Bopeebo')
 		{
 			boyfriend.playAnim('hey', true);
 
@@ -2346,7 +2345,7 @@ class PlayState extends MusicBeatState
 				if (!trainMoving)
 					trainCooldown += 1;
 
-				if (totalBeats % 4 == 0)
+				if (curBeat % 4 == 0)
 				{
 					phillyCityLights.forEach(function(light:FlxSprite)
 					{
@@ -2359,7 +2358,7 @@ class PlayState extends MusicBeatState
 					// phillyCityLights.members[curLight].alpha = 1;
 				}
 
-				if (totalBeats % 8 == 4 && FlxG.random.bool(30) && !trainMoving && trainCooldown > 8)
+				if (curBeat % 8 == 4 && FlxG.random.bool(30) && !trainMoving && trainCooldown > 8)
 				{
 					trainCooldown = FlxG.random.int(-4, 0);
 					trainStart();

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -140,6 +140,7 @@ class PlayState extends MusicBeatState
 		if (SONG == null)
 			SONG = Song.loadFromJson('tutorial');
 
+		Conductor.mapBPMChanges(SONG);
 		Conductor.changeBPM(SONG.bpm);
 
 		switch (SONG.song.toLowerCase())
@@ -1446,6 +1447,8 @@ class PlayState extends MusicBeatState
 		}
 
 		FlxG.watch.addQuick("beatShit", totalBeats);
+		FlxG.watch.addQuick("stepShit", totalSteps);
+
 
 		if (curSong == 'Fresh')
 		{
@@ -2283,7 +2286,7 @@ class PlayState extends MusicBeatState
 		// FlxG.log.add('change bpm' + SONG.notes[Std.int(curStep / 16)].changeBPM);
 
 		// HARDCODING FOR MILF ZOOMS!
-		if (curSong.toLowerCase() == 'milf' && curBeat >= 168 && curBeat <= 200 && camZooming && FlxG.camera.zoom < 1.35)
+		if (curSong.toLowerCase() == 'milf' && curBeat >= 168 && curBeat < 200 && camZooming && FlxG.camera.zoom < 1.35)
 		{
 			FlxG.camera.zoom += 0.015;
 			camHUD.zoom += 0.03;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2273,8 +2273,8 @@ class PlayState extends MusicBeatState
 				Conductor.changeBPM(SONG.notes[Math.floor(curStep / 16)].bpm);
 				FlxG.log.add('CHANGED BPM!');
 			}
-			else
-				Conductor.changeBPM(SONG.bpm);
+			//else
+				//Conductor.changeBPM(SONG.bpm);
 
 			// Dad doesnt interupt his own notes
 			if (SONG.notes[Math.floor(curStep / 16)].mustHitSection)

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2261,7 +2261,6 @@ class PlayState extends MusicBeatState
 
 	override function beatHit()
 	{
-		wiggleShit.update(Conductor.crochet);
 		super.beatHit();
 
 		if (generatedMusic)
@@ -2284,6 +2283,7 @@ class PlayState extends MusicBeatState
 				dad.dance();
 		}
 		// FlxG.log.add('change bpm' + SONG.notes[Std.int(curStep / 16)].changeBPM);
+		wiggleShit.update(Conductor.crochet);
 
 		// HARDCODING FOR MILF ZOOMS!
 		if (curSong.toLowerCase() == 'milf' && curBeat >= 168 && curBeat < 200 && camZooming && FlxG.camera.zoom < 1.35)

--- a/source/Song.hx
+++ b/source/Song.hx
@@ -12,8 +12,6 @@ typedef SwagSong =
 	var song:String;
 	var notes:Array<SwagSection>;
 	var bpm:Int;
-	var sections:Int;
-	var sectionLengths:Array<Dynamic>;
 	var needsVoices:Bool;
 	var speed:Float;
 
@@ -27,25 +25,17 @@ class Song
 	public var song:String;
 	public var notes:Array<SwagSection>;
 	public var bpm:Int;
-	public var sections:Int;
-	public var sectionLengths:Array<Dynamic> = [];
 	public var needsVoices:Bool = true;
 	public var speed:Float = 1;
 
 	public var player1:String = 'bf';
 	public var player2:String = 'dad';
 
-	public function new(song, notes, bpm, sections)
+	public function new(song, notes, bpm)
 	{
 		this.song = song;
 		this.notes = notes;
 		this.bpm = bpm;
-		this.sections = sections;
-
-		for (i in 0...notes.length)
-		{
-			this.sectionLengths.push(notes[i]);
-		}
 	}
 
 	public static function loadFromJson(jsonInput:String, ?folder:String):SwagSong
@@ -72,9 +62,7 @@ class Song
 
 				daNotes = songData.notes;
 				daSong = songData.song;
-				daSections = songData.sections;
-				daBpm = songData.bpm;
-				daSectionLengths = songData.sectionLengths; */
+				daBpm = songData.bpm; */
 
 		return parseJSONshit(rawJson);
 	}


### PR DESCRIPTION
Tweaks changeBPM functionality so that the BPM is not reset back to the original after having been changed.

Worth noting is that this may cause inconsistencies with the chart editor, particularly in the function ``recalculateSteps()``.
A potential fix for this could be done by doing this for its for loop instead:

```haxe
var bpm:Int = _song.bpm;

for (i in 0...curSection)
{
	steps += 16;

	if (_song.notes[i].changeBPM)
		bpm = _song.notes[i].bpm;
	timeShit += (((60 / bpm) * 1000) / 4) * 16;
}
```
But the chart editor scares me so I do not touch it, not that there are many songs I could test with.