### PR TITLE
Resync by music instead of vocals

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2237,12 +2237,9 @@ class PlayState extends MusicBeatState
 
 	override function stepHit()
 	{
-		if (SONG.needsVoices)
+		if (FlxG.sound.music.time > Conductor.songPosition + 20 || FlxG.sound.music.time < Conductor.songPosition - 20)
 		{
-			if (vocals.time > Conductor.songPosition + 20 || vocals.time < Conductor.songPosition - 20)
-			{
-				resyncVocals();
-			}
+			resyncVocals();
 		}
 
 		if (dad.curCharacter == 'spooky' && totalSteps % 4 == 2)


### PR DESCRIPTION
Before, songs without vocals would become desynced whenever the game lagged/stuttered/froze. Now, the notes will stay synced no matter what.