### PR TITLE
score value ease-out fix

### DIFF
--- a/source/FreeplayState.hx
+++ b/source/FreeplayState.hx
@@ -159,7 +159,11 @@ class FreeplayState extends MusicBeatState
 			FlxG.sound.music.volume += 0.5 * FlxG.elapsed;
 		}
 
-		lerpScore = Math.floor(FlxMath.lerp(lerpScore, intendedScore, 0.4));
+		if ( lerpScore != intendedScore )
+			if ( lerpScore == intendedScore - 1 )
+				lerpScore = intendedScore;
+			else
+				lerpScore = Math.floor(FlxMath.lerp(lerpScore, intendedScore, 0.5));
 
 		if (Math.abs(lerpScore - intendedScore) <= 10)
 			lerpScore = intendedScore;

--- a/source/FreeplayState.hx
+++ b/source/FreeplayState.hx
@@ -165,9 +165,6 @@ class FreeplayState extends MusicBeatState
 			else
 				lerpScore = Math.floor(FlxMath.lerp(lerpScore, intendedScore, 0.5));
 
-		if (Math.abs(lerpScore - intendedScore) <= 10)
-			lerpScore = intendedScore;
-
 		scoreText.text = "PERSONAL BEST:" + lerpScore;
 
 		var upP = controls.UP_P;

--- a/source/StoryMenuState.hx
+++ b/source/StoryMenuState.hx
@@ -217,7 +217,11 @@ class StoryMenuState extends MusicBeatState
 	override function update(elapsed:Float)
 	{
 		// scoreText.setFormat('VCR OSD Mono', 32);
-		lerpScore = Math.floor(FlxMath.lerp(lerpScore, intendedScore, 0.5));
+		if ( lerpScore != intendedScore )
+			if ( lerpScore == intendedScore - 1 )
+				lerpScore = intendedScore;
+			else
+				lerpScore = Math.floor(FlxMath.lerp(lerpScore, intendedScore, 0.5));
 
 		scoreText.text = "WEEK SCORE:" + lerpScore;
 


### PR DESCRIPTION
redoing because i thought i could learn git and now i am experiencing hell

tiny fix so that when the week score transitions from a smaller value to a greater one, it reaches the intended value. currently, if the score tries going up to a value like 10300, it gets stuck at 10299.
also changed the free play menu score's lerp ratio to be 0.5 like the story menu, just for some uniformity idk