### PR TITLE
feat(extra): Remove extra imports

### DIFF
--- a/source/ChartingState.hx
+++ b/source/ChartingState.hx
@@ -28,8 +28,6 @@ import haxe.Json;
 import lime.utils.Assets;
 import openfl.events.Event;
 import openfl.events.IOErrorEvent;
-import openfl.events.IOErrorEvent;
-import openfl.events.IOErrorEvent;
 import openfl.media.Sound;
 import openfl.net.FileReference;
 import openfl.utils.ByteArray;


### PR DESCRIPTION
Remove 2 extra imports, `IOErrorEvent` was imported already.