### PR TITLE
Update freeplaySonglist to the newer freeplay format

### DIFF
--- a/assets/preload/data/freeplayInit.json
+++ b/assets/preload/data/freeplayInit.json
@@ -1,0 +1,1 @@
+{"init": [["Tutorial", 0, "gf"],["Bopeebo", 1, "dad"],["Fresh", 1, "dad"],["Dadbattle", 1, "dad"]]}

--- a/assets/preload/data/freeplaySonglist.txt
+++ b/assets/preload/data/freeplaySonglist.txt
@@ -1,1 +1,0 @@
-Tutorial

--- a/source/FreeplayState.hx
+++ b/source/FreeplayState.hx
@@ -12,8 +12,13 @@ import flixel.math.FlxMath;
 import flixel.text.FlxText;
 import flixel.util.FlxColor;
 import lime.utils.Assets;
+import haxe.Json;
 
 using StringTools;
+
+typedef JsonSongs = {
+	var init:Array<Dynamic>;
+}
 
 class FreeplayState extends MusicBeatState
 {
@@ -32,14 +37,14 @@ class FreeplayState extends MusicBeatState
 	private var curPlaying:Bool = false;
 
 	private var iconArray:Array<HealthIcon> = [];
+	private var json:JsonSongs;
 
 	override function create()
 	{
-		var initSonglist = CoolUtil.coolTextFile(Paths.txt('freeplaySonglist'));
-
-		for (i in 0...initSonglist.length)
+		json = Json.parse(Assets.getText('assets/data/freeplayInit.json'));
+		for (i in json.init)
 		{
-			songs.push(new SongMetadata(initSonglist[i], 1, 'gf'));
+			addWeek([''+Std.string(i[0])],i[1],[''+Std.string(i[2])]);
 		}
 
 		/* 
@@ -61,8 +66,8 @@ class FreeplayState extends MusicBeatState
 		isDebug = true;
 		#end
 
-		if (StoryMenuState.weekUnlocked[2] || isDebug)
-			addWeek(['Bopeebo', 'Fresh', 'Dadbattle'], 1, ['dad']);
+		/*if (StoryMenuState.weekUnlocked[2] || isDebug)
+			addWeek(['Bopeebo', 'Fresh', 'Dadbattle'], 1, ['dad']);*/
 
 		if (StoryMenuState.weekUnlocked[2] || isDebug)
 			addWeek(['Spookeez', 'South', 'Monster'], 2, ['spooky']);

--- a/source/FreeplayState.hx
+++ b/source/FreeplayState.hx
@@ -44,7 +44,7 @@ class FreeplayState extends MusicBeatState
 		json = Json.parse(Assets.getText('assets/data/freeplayInit.json'));
 		for (i in json.init)
 		{
-			addWeek([''+Std.string(i[0])],i[1],[''+Std.string(i[2])]);
+			songs.push(new SongMetadata(''+Std.string(i[0]),i[1],''+Std.string(i[2])));
 		}
 
 		/* 


### PR DESCRIPTION
This PR updates freeplay to load the tutorial and week one songs from a json similar to how it was done before [this commit](https://github.com/ninjamuffin99/Funkin/commit/5632736ed462a0f108250dcbbc50da66549c9186). 

Due to this commit freeplaySonglist doesn't work properly and loads every song described in that in that file as a week one song with gf's icon. This PR intends to fix that by making freeplaySonglist a json with each song inside of it having it's own icon and weeknum values. 

(wish i could've used tjson for the fancy formatting but unfortunately that doesn't work on HTML 😔) 