### PR TITLE
Discord RPC fix

### DIFF
--- a/source/Discord.hx
+++ b/source/Discord.hx
@@ -28,6 +28,11 @@ class DiscordClient
 		DiscordRpc.shutdown();
 	}
 
+	public static function shutdown()
+	{
+		DiscordRpc.shutdown();
+	}
+	
 	static function onReady()
 	{
 		DiscordRpc.presence({

--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -96,6 +96,10 @@ class TitleState extends MusicBeatState
 
 		#if desktop
 		DiscordClient.initialize();
+		
+		Application.current.onExit.add (function (exitCode) {
+			DiscordClient.shutdown();
+		 });
 		#end
 	}
 


### PR DESCRIPTION
so basically we just add a call to the onExit event and when we exit the game we shut down the discord rpc. Cuz otherwise it doesn't work correctly.