### PR TITLE
Loading gf-christmas as a character will no longer cause the game to crash

### DIFF
--- a/source/HealthIcon.hx
+++ b/source/HealthIcon.hx
@@ -31,6 +31,7 @@ class HealthIcon extends FlxSprite
 		animation.add('spirit', [23, 23], 0, false, isPlayer);
 		animation.add('bf-old', [14, 15], 0, false, isPlayer);
 		animation.add('gf', [16], 0, false, isPlayer);
+		animation.add('gf-christmas', [16], 0, false, isPlayer);
 		animation.add('parents-christmas', [17], 0, false, isPlayer);
 		animation.add('monster', [19, 20], 0, false, isPlayer);
 		animation.add('monster-christmas', [19, 20], 0, false, isPlayer);


### PR DESCRIPTION
adds gf-christmas to healthicon.hx so the game doesn't crash when you attempt to load her.