### PR TITLE
compilation with haxe 4.0.x

### DIFF
--- a/source/Controls.hx
+++ b/source/Controls.hx
@@ -406,7 +406,7 @@ class Controls extends FlxActionSet
 		{
 			case null:
 				// add all
-				#if (haxe >= "4.0.0")
+				#if (haxe >= "4.1.0")
 				for (gamepad in controls.gamepadsAdded)
 					if (!gamepadsAdded.contains(gamepad))
 						gamepadsAdded.push(gamepad);


### PR DESCRIPTION
`.contains()` did not exist until Haxe 4.1.0. This allows Haxe 4.0.x users to compile the game correctly.