### PR TITLE
Remove Newgrounds logging from menu scrolling

### DIFF
--- a/source/FreeplayState.hx
+++ b/source/FreeplayState.hx
@@ -257,11 +257,6 @@ class FreeplayState extends MusicBeatState
 
 	function changeSelection(change:Int = 0)
 	{
-		#if !switch
-		NGio.logEvent('Fresh');
-		#end
-
-		// NGio.logEvent('Fresh');
 		FlxG.sound.play(Paths.sound('scrollMenu'), 0.4);
 
 		curSelected += change;

--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -101,8 +101,6 @@ class MainMenuState extends MusicBeatState
 		versionShit.setFormat("VCR OSD Mono", 16, FlxColor.WHITE, LEFT, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
 		add(versionShit);
 
-		// NG.core.calls.event.logEvent('swag').send();
-
 		changeItem();
 
 		super.create();

--- a/source/OptionsMenu.hx
+++ b/source/OptionsMenu.hx
@@ -99,10 +99,6 @@ class OptionsMenu extends MusicBeatState
 
 	function changeSelection(change:Int = 0)
 	{
-		#if !switch
-		NGio.logEvent('Fresh');
-		#end
-
 		FlxG.sound.play(Paths.sound('scrollMenu'), 0.4);
 
 		curSelected += change;


### PR DESCRIPTION
Every selection change in the Freeplay and Options menus causes a `'Fresh"` event to be logged to Newgrounds. This generates a lot of network requests when quickly scrolling through the options, which might be causing #744.

My guess is that this logging isn't used, so this PR removes the logging. (If the logging is used, I'll close the PR.)