### PR TITLE
Added Override Update Check

### DIFF
--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -32,6 +32,9 @@ using StringTools;
 
 class TitleState extends MusicBeatState
 {
+	static var overrideUpdateCheck:Bool = false;
+	// ^^ For modders that don't want players do deal with an update notification all the damn time
+
 	static var initialized:Bool = false;
 
 	var blackScreen:FlxSprite;
@@ -292,7 +295,7 @@ class TitleState extends MusicBeatState
 
 				var version:String = "v" + Application.current.meta.get('version');
 
-				if (version.trim() != NGio.GAME_VER_NUMS.trim() && !OutdatedSubState.leftState)
+				if (!overrideUpdateCheck && version.trim() != NGio.GAME_VER_NUMS.trim() && !OutdatedSubState.leftState)
 				{
 					FlxG.switchState(new OutdatedSubState());
 					trace('OLD VERSION!');


### PR DESCRIPTION
Modders don't want to have to deal with players getting links to the vanilla game whenever the mod is based on an older version. This pull request adds a toggle to let modders choose whether or not they want an update screen, and if enabled, new versions are completely ignored.

Update: I want to make this the foundation for a potential in-game setting to disable update notifications, not just a toggle exclusively for modders as I originally intended.