### PR TITLE
Replace deprecated line in PlayState.hx

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -147,7 +147,7 @@ class PlayState extends MusicBeatState
 		FlxG.cameras.reset(camGame);
 		FlxG.cameras.add(camHUD);
 
-		FlxCamera.defaultCameras = [camGame];
+		FlxG.cameras.setDefaultDrawTarget(camGame, true);
 
 		persistentUpdate = true;
 		persistentDraw = true;


### PR DESCRIPTION
Since HaxeFlixel 4.9.0 released, the "defaultCameras" variable from FlxCamera is deprecated.
So this pull request, basically changes that, and uses "setDefaultDrawTarget" from "FlxG.cameras", that it's updated.

Game can compile fine with the deprecated variable, but it being deprecated annoys me lol!

