### PR TITLE
remove -debug from build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved.
 * MSVC v141 - VS 2017 C++ x64/x86 build tools
 * MSVC v140 - VS 2015 C++ build tools (v14.00)
 
-This will install about 22GB of crap, but once that is done you can open up a command line in the project's directory and run `lime test windows -debug`. Once that command finishes (it takes forever even on a higher end PC), you can run FNF from the .exe file under export\release\windows\bin
+This will install about 22GB of crap, but once that is done you can open up a command line in the project's directory and run `lime test windows`. Once that command finishes (it takes forever even on a higher end PC), you can run FNF from the .exe file under export\release\windows\bin
 As for Mac, 'lime test mac -debug' should work, if not the internet surely has a guide on how to compile Haxe stuff for Mac.
 
 ### Additional guides

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved.
 * MSVC v141 - VS 2017 C++ x64/x86 build tools
 * MSVC v140 - VS 2015 C++ build tools (v14.00)
 
-This will install about 22GB of crap, but once that is done you can open up a command line in the project's directory and run `lime test windows`. Once that command finishes (it takes forever even on a higher end PC), you can run FNF from the .exe file under export\release\windows\bin
+This will install about 22GB of crap, but once that is done you can open up a command line in the project's directory and run `lime test windows`. If oyu need debug tools, run `lime test windows -debug`. Once that command finishes (it takes forever even on a higher end PC), you can run FNF from the .exe file under `export\release\windows\bin` or `export\debug\windows\bin`, depending on the build command used.
 As for Mac, 'lime test mac' should work, if not the internet surely has a guide on how to compile Haxe stuff for Mac.
 
 ### Additional guides

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved.
 * MSVC v141 - VS 2017 C++ x64/x86 build tools
 * MSVC v140 - VS 2015 C++ build tools (v14.00)
 
-This will install about 22GB of crap, but once that is done you can open up a command line in the project's directory and run `lime test windows`. If oyu need debug tools, run `lime test windows -debug`. Once that command finishes (it takes forever even on a higher end PC), you can run FNF from the .exe file under `export\release\windows\bin` or `export\debug\windows\bin`, depending on the build command used.
+This will install about 22GB of crap, but once that is done you can open up a command line in the project's directory and run `lime test windows`. If you need debug tools, run `lime test windows -debug`. Once that command finishes (it takes forever even on a higher end PC), you can run FNF from the .exe file under `export\release\windows\bin` or `export\debug\windows\bin`, depending on the build command used.
 As for Mac, 'lime test mac' should work, if not the internet surely has a guide on how to compile Haxe stuff for Mac.
 
 ### Additional guides


### PR DESCRIPTION
because it doesnt create a "release" folder under export, and fucks shit up

when ran with the -debug flag, it creates a /export/debug folder instead of /export/release, and when you go into a level theres a bunch of debug shit on screen lmao
![image](https://user-images.githubusercontent.com/24574201/124750798-cc537800-df1d-11eb-9168-899aa5427e4a.png)
