### PR TITLE
Remove the extra haxeflixel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ IF YOU WANT TO COMPILE THE GAME YOURSELF, CONTINUE READING!!!
 
 First, you need to install [Haxe 4.1.5](https://haxe.org/download/version/4.1.5/) (Download 4.1.5 instead of 4.2.0 because 4.2.0 is broken and is not working with gits properly...)
 
+If you're on Windows and don't have admin, you can install Haxe with [Scoop](https://scoop.sh)
+
 Other installations you'd need are the additional libraries, a fully updated list will be in `Project.xml` in the project root. Currently, these are all of the things you need to install:
 ```
 flixel

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ haxelib run lime setup
 haxelib run lime setup flixel
 ```
 
-You'll also need to install a couple things that involve Gits. To do this, you need to do a few things first.
+You'll also need to install a couple things that involve Git. To do this, you need to do a few things first.
 1. Download [git-scm](https://git-scm.com/downloads). Works for Windows, Mac, and Linux, just select your build.
 2. Follow instructions to install the application properly.
 3. Run `haxelib git polymod https://github.com/larsiusprime/polymod.git` to install Polymod.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ flixel-addons
 flixel-ui
 hscript
 newgrounds
+lime
 ```
 So for each of those type `haxelib install [library]` so shit like `haxelib install newgrounds`
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ IF YOU WANT TO COMPILE THE GAME YOURSELF, CONTINUE READING!!!
 
 ### Installing the Required Programs
 
-First, you need to install Haxe and HaxeFlixel. I'm too lazy to write and keep updated with that setup (which is pretty simple). 
-1. [Install Haxe 4.1.5](https://haxe.org/download/version/4.1.5/) (Download 4.1.5 instead of 4.2.0 because 4.2.0 is broken and is not working with gits properly...)
-2. [Install HaxeFlixel](https://haxeflixel.com/documentation/install-haxeflixel/) after downloading Haxe
+First, you need to install [Haxe 4.1.5](https://haxe.org/download/version/4.1.5/) (Download 4.1.5 instead of 4.2.0 because 4.2.0 is broken and is not working with gits properly...)
 
 Other installations you'd need are the additional libraries, a fully updated list will be in `Project.xml` in the project root. Currently, these are all of the things you need to install:
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ lime
 ```
 So for each of those type `haxelib install [library]` so shit like `haxelib install newgrounds`
 
+To setup lime, run this two commands
+```
+haxelib run lime setup
+haxelib run lime setup flixel
+```
+
 You'll also need to install a couple things that involve Gits. To do this, you need to do a few things first.
 1. Download [git-scm](https://git-scm.com/downloads). Works for Windows, Mac, and Linux, just select your build.
 2. Follow instructions to install the application properly.


### PR DESCRIPTION
If you install Flixel using haxelib as the instructions say, you don't need to go to the link to install it again