### PR TITLE
add notice to build section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ class APIStuff
 and you should be good to go there.
 
 ### Compiling game
-NOTE: If you see any messages relating to deprectated packages, ignore them. They're just warnings that don't affect compiling
+NOTE: If you see any messages relating to deprecated packages, ignore them. They're just warnings that don't affect compiling
 
 Once you have all those installed, it's pretty easy to compile the game. You just need to run `lime test html5 -debug` in the root of the project to build and run the HTML5 version. (command prompt navigation guide can be found here: [https://ninjamuffin99.newgrounds.com/news/post/1090480](https://ninjamuffin99.newgrounds.com/news/post/1090480))
 To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved. For Linux, you only need to open a terminal in the project directory and run `lime test linux -debug` and then run the executable file in export/release/linux/bin. For Windows, you need to install Visual Studio Community 2019. While installing VSC, don't click on any of the options to install workloads. Instead, go to the individual components tab and choose the following:

--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ class APIStuff
 and you should be good to go there.
 
 ### Compiling game
+NOTE: If you see any messages relating to deprectated packages, ignore them. They're just warnings that don't affect compiling
 
-Once you have all those installed, it's pretty easy to compile the game. You just need to run 'lime test html5 -debug' in the root of the project to build and run the HTML5 version. (command prompt navigation guide can be found here: [https://ninjamuffin99.newgrounds.com/news/post/1090480](https://ninjamuffin99.newgrounds.com/news/post/1090480))
-To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved. For Linux, you only need to open a terminal in the project directory and run 'lime test linux -debug' and then run the executable file in export/release/linux/bin. For Windows, you need to install Visual Studio Community 2019. While installing VSC, don't click on any of the options to install workloads. Instead, go to the individual components tab and choose the following:
+Once you have all those installed, it's pretty easy to compile the game. You just need to run `lime test html5 -debug` in the root of the project to build and run the HTML5 version. (command prompt navigation guide can be found here: [https://ninjamuffin99.newgrounds.com/news/post/1090480](https://ninjamuffin99.newgrounds.com/news/post/1090480))
+To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved. For Linux, you only need to open a terminal in the project directory and run `lime test linux -debug` and then run the executable file in export/release/linux/bin. For Windows, you need to install Visual Studio Community 2019. While installing VSC, don't click on any of the options to install workloads. Instead, go to the individual components tab and choose the following:
 * MSVC v142 - VS 2019 C++ x64/x86 build tools
 * Windows SDK (10.0.17763.0)
 


### PR DESCRIPTION
I've been seeing some issues lately relating to how they get an "error" when compiling. When in reality, they're just simple warnings that can easily be ignored

This PR adds a note to the building section telling people to just ignore the deprecated warnings to address the compiling "issues".
I also went ahead and changed formatting for build commands to match `lime test windows -debug`