### PR TITLE
Fix Down Arrow Sprite Atlas Bug (idk how any body didn't notice this).

### DIFF
--- a/assets/shared/images/NOTE_assets.xml
+++ b/assets/shared/images/NOTE_assets.xml
@@ -2,7 +2,7 @@
 <TextureAtlas imagePath="NOTE_assets.png">
 	<!-- Created with Adobe Animate version 20.0.0.17400 -->
 	<!-- http://www.adobe.com/products/animate.html -->
-	<SubTexture name="arrowDOWN0000" x="0" y="235" width="157" height="153"/>
+	<SubTexture name="arrowDOWN0000" x="0" y="235" width="156" height="153"/>
 	<SubTexture name="arrowLEFT0000" x="310" y="235" width="153" height="157"/>
 	<SubTexture name="arrowRIGHT0000" x="157" y="235" width="153" height="157"/>
 	<SubTexture name="arrowUP0000" x="784" y="232" width="157" height="153"/>


### PR DESCRIPTION
before:
![WrpPnm5cPY](https://user-images.githubusercontent.com/44223347/133908210-f6f0b489-c0ee-4c80-afa2-044e1a2bb31e.png)

after:
![msedge_nbS4QCl4PG](https://user-images.githubusercontent.com/44223347/133908215-5f750695-e46e-41e3-8f5a-d3398f85df0b.png)

this bug has been bothering me for a while.