### PR TITLE
Adding a Dockerfile to compile HTML5 target

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,4 +24,3 @@ WORKDIR /fnf
 VOLUME /fnf
 
 ENTRYPOINT ["lime", "build", "html5"]
-

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,13 @@
 {
-"build": { "dockerfile": "Dockerfile" },
-"forwardPorts": [
-	8080
-],
-"extensions": [
-	"nadako.vshaxe",
-	"ms-azuretools.vscode-docker",
-	"openfl.lime-vscode-extension"
-]
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "forwardPorts": [
+    8080
+  ],
+  "extensions": [
+    "nadako.vshaxe",
+    "ms-azuretools.vscode-docker",
+    "openfl.lime-vscode-extension"
+  ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+"build": { "dockerfile": "Dockerfile" },
+"forwardPorts": [
+	8080
+],
+"extensions": [
+	"nadako.vshaxe",
+	"ms-azuretools.vscode-docker",
+	"openfl.lime-vscode-extension"
+]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,38 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build Debug HTML5",
+      "type": "shell",
+      "command": "lime build html5 -debug",
+      "group": "build"
+    },
+    {
+      "label": "Build Release HTML5",
+      "type": "shell",
+      "command": "lime build html5",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Start Release HTML5",
+      "type": "shell",
+      "command": "python -m SimpleHTTPServer 8080",
+      "options": {
+        "cwd": "${workspaceFolder}/export/release/html5/bin"
+      }
+    },
+    {
+      "label": "Start Debug HTML5",
+      "type": "shell",
+      "command": "python -m SimpleHTTPServer 8080",
+      "options": {
+        "cwd": "${workspaceFolder}/export/debug/html5/bin"
+      }
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM haxe:4.1.5-buster
+
+# Installing sudo as a workaround for lime that uses sudo in it's setup (sorry I'm lazy to try to find a good solution for it)
+RUN apt update && apt install git sudo -y
+
+# Install haxe dependencies
+RUN haxelib install lime \ 
+    && haxelib install flixel \ 
+    && haxelib install flixel-addons \ 
+    && haxelib install flixel-ui \
+    && haxelib install hscript \ 
+    && haxelib install newgrounds \ 
+    && haxelib install openfl \ 
+    && haxelib git polymod https://github.com/larsiusprime/polymod.git \ 
+    && haxelib git discord_rpc https://github.com/Aidan63/linc_discord-rpc.git \ 
+    && haxelib git flixel-addons https://github.com/HaxeFlixel/flixel-addons
+
+# Setup lime
+RUN haxelib run lime setup -y
+
+WORKDIR /fnf
+
+# This will require to use -v argument pointing to your FNF source code using /fnf as destination when the container is run
+VOLUME /fnf
+
+ENTRYPOINT ["lime", "build", "html5"]
+

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ class APIStuff
 	public static var API:String = "";
 	public static var EncKey:String = "";
 }
-
 ```
 
 and you should be good to go there.
@@ -83,6 +82,32 @@ To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved.
 
 Once that is done you can open up a command line in the project's directory and run `lime test windows -debug`. Once that command finishes (it takes forever even on a higher end PC), you can run FNF from the .exe file under export\release\windows\bin
 As for Mac, 'lime test mac -debug' should work, if not the internet surely has a guide on how to compile Haxe stuff for Mac.
+
+### Compiling HTML5 version using Docker
+
+Run this commands:
+
+```bash
+docker build . -t fnf:mine
+docker run --name compile_fnf --rm -v <FULL PATH TO YOUR FNF REPO>:/fnf fnf:mine
+```
+
+If you want to build a HTML5 debug version add `-debug` at the end of docker command
+
+```bash
+docker run --name compile_fnf --rm -v <FULL PATH TO YOUR FNF REPO>:/fnf fnf:mine -debug
+```
+
+To run the thing that you just compiled, you need to serve `export/[debug|release]/bin` with an HTTP server, being `python` the easiest
+
+```bash
+# Python version is 3.X
+python -m http.server 8080
+# Python version is 2.X
+python -m SimpleHTTPServer 8080
+```
+
+Then
 
 ### Additional guides
 

--- a/README.md
+++ b/README.md
@@ -83,35 +83,40 @@ To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved.
 Once that is done you can open up a command line in the project's directory and run `lime test windows -debug`. Once that command finishes (it takes forever even on a higher end PC), you can run FNF from the .exe file under export\release\windows\bin
 As for Mac, 'lime test mac -debug' should work, if not the internet surely has a guide on how to compile Haxe stuff for Mac.
 
-### FNF now supports [VSCode Devcontainers](https://code.visualstudio.com/docs/remote/containers)
+### Using [VSCode Dev Containers](https://code.visualstudio.com/docs/remote/containers)
 
-There are some VSCode task created for compiling and running HTML5 versions of FNF inside a devcontainer
+Provided inside of the repository are some VS Code tasks created for compiling and running HTML5 builds inside of a development container.
 
 ### Compiling HTML5 version using Docker
 
-Run this commands:
+Run these commands:
 
 ```bash
 docker build -f .devcontainer/Dockerfile -t fnf:mine .
 docker run --name compile_fnf --rm -v <FULL PATH TO YOUR FNF REPO>:/fnf fnf:mine
 ```
 
-If you want to build a HTML5 debug version add `-debug` at the end of docker command
+To compile a debug HTML5 build, append `-debug` to the end of the `docker run` command.
 
-```bash
-docker run --name compile_fnf --rm -v <FULL PATH TO YOUR FNF REPO>:/fnf fnf:mine -debug
-```
-
-To run the thing that you just compiled, you need to serve `export/[debug|release]/bin` with an HTTP server, being `python` the easiest
-
+In order to play the HTML5 version that you compiled, is needed a HTTP Server capable to serve the files of the game.
+Those files are located on the `export/[debug|release]/bin` directory.
+One option is to use `python`, which includes an HTTP Server.
+Here is an example to run a release version using Python 3 (don't forget to replace <port>, e.g 8080):
 ```bash
 # Python version is 3.X
-python -m http.server 8080
-# Python version is 2.X
-python -m SimpleHTTPServer 8080
+cd export/release/bin
+python -m http.server <port>
 ```
 
-Then go to localhost:8080 in your browser to play FNF!!!
+Here is an example to run a release version using Python 2 (don't forget to replace <port>, e.g 8080):
+
+```bash
+# Python version is 2.X
+cd export/release/bin
+python -m SimpleHTTPServer <port>
+```
+
+Visit localhost:<port> (or 127.0.0.1:<port>) in your browser to run the game hosted locally on your machine.
 
 ### Additional guides
 

--- a/README.md
+++ b/README.md
@@ -83,12 +83,16 @@ To run it from your desktop (Windows, Mac, Linux) it can be a bit more involved.
 Once that is done you can open up a command line in the project's directory and run `lime test windows -debug`. Once that command finishes (it takes forever even on a higher end PC), you can run FNF from the .exe file under export\release\windows\bin
 As for Mac, 'lime test mac -debug' should work, if not the internet surely has a guide on how to compile Haxe stuff for Mac.
 
+### FNF now supports [VSCode Devcontainers](https://code.visualstudio.com/docs/remote/containers)
+
+There are some VSCode task created for compiling and running HTML5 versions of FNF inside a devcontainer
+
 ### Compiling HTML5 version using Docker
 
 Run this commands:
 
 ```bash
-docker build . -t fnf:mine
+docker build -f .devcontainer/Dockerfile -t fnf:mine .
 docker run --name compile_fnf --rm -v <FULL PATH TO YOUR FNF REPO>:/fnf fnf:mine
 ```
 
@@ -107,7 +111,7 @@ python -m http.server 8080
 python -m SimpleHTTPServer 8080
 ```
 
-Then
+Then go to localhost:8080 in your browser to play FNF!!!
 
 ### Additional guides
 


### PR DESCRIPTION
The idea is to give to occasional developer an easy way to play around with FNF without polluting their machines with the needed dependencies.
Check README.md for instructions.
Also added [VSCode devcontainers](https://code.visualstudio.com/docs/remote/containers) support.